### PR TITLE
Disable stable pids and is_available outside event-driven

### DIFF
--- a/src/PSOTraceBuilder.cpp
+++ b/src/PSOTraceBuilder.cpp
@@ -211,7 +211,7 @@ void PSOTraceBuilder::mark_unavailable(int proc, int aux){
 }
 
 bool PSOTraceBuilder::is_available(int proc, int aux){
-  return threads[proc*2].available;
+  return true; // Not supported
 }
 
 bool PSOTraceBuilder::is_replaying() const {

--- a/src/RFSCTraceBuilder.cpp
+++ b/src/RFSCTraceBuilder.cpp
@@ -176,7 +176,7 @@ void RFSCTraceBuilder::mark_unavailable(int proc, int aux){
 }
 
 bool RFSCTraceBuilder::is_available(int proc, int aux){
-  return threads[proc*2].available;
+  return threads[ipid(proc,aux)].available;
 }
 
 bool RFSCTraceBuilder::is_replaying() const {
@@ -304,8 +304,9 @@ IID<CPid> RFSCTraceBuilder::get_iid() const{
 }
 
 int RFSCTraceBuilder::get_spid(int pid){
-  CPid cpid = threads[pid*2].cpid;
-  return (SPS.get_spid(cpid))/2;
+  // CPid cpid = threads[ipid(proc,aux)].cpid;
+  // return (SPS.get_spid(cpid));
+  return pid;
 } 
 
 static std::string rpad(std::string s, int n){

--- a/src/TSOTraceBuilder.cpp
+++ b/src/TSOTraceBuilder.cpp
@@ -237,7 +237,7 @@ void TSOTraceBuilder::mark_unavailable(int proc, int aux){
 }
 
 bool TSOTraceBuilder::is_available(int proc, int aux){
-  return threads[ipid(proc,aux)].available;
+  return true; // Not supported
 }
 
 bool TSOTraceBuilder::is_replaying() const {
@@ -400,8 +400,9 @@ IID<CPid> TSOTraceBuilder::get_iid(unsigned i) const{
 }
 
 int TSOTraceBuilder::get_spid(int pid){
-  CPid cpid = threads[pid*2].cpid;
-  return (SPS.get_spid(cpid))/2;
+  // CPid cpid = threads[pid*2].cpid;
+  // return (SPS.get_spid(cpid))/2;
+  return pid;
 }
 
 static std::string rpad(std::string s, int n){


### PR DESCRIPTION
This makes them pass their tests, and should work as in upstream. When
we have more time, we can debug the `is_available` stuff, and do the
stable pids in a more robust way.